### PR TITLE
change view filter for /account/edit

### DIFF
--- a/Machete.Web/Controllers/AccountController.cs
+++ b/Machete.Web/Controllers/AccountController.cs
@@ -85,8 +85,12 @@ namespace Machete.Web.Controllers
                     IsLockedOut = u.IsLockedOut ? "Yes" : "No",
                     IsOnline = DbFunctions.DiffHours(u.LastLoginDate, DateTime.Now) < 1 ? "Yes" : "No",
                     CreationDate = u.CreateDate,
-                    LastLoginDate = u.LastLoginDate
-                }).Where (u => !u.UserName.Contains("@"));
+                    LastLoginDate = u.LastLoginDate,
+                    IsHirer = u.Roles.Contains(_context.Roles.FirstOrDefault(role => role.Name == "Hirer"))
+                })
+                .Where(u => !u.IsHirer) // replaces hack .Contains("@"); for email addresses, which hides legit users
+                .Where(u => !u.UserName.Equals("jadmin"))
+                .Where(u => !u.UserName.Contains("ndlon")); // ndlon addresses are invariably administrators
 
             return View(model);
         }

--- a/Machete.Web/StartupConfiguration.cs
+++ b/Machete.Web/StartupConfiguration.cs
@@ -93,12 +93,12 @@ namespace Machete.Web
             services.Configure<IdentityOptions>(options =>
             {
                 // Password settings; we are relying on validation
-                options.Password.RequireDigit = true;
-                options.Password.RequiredLength = 8;
-                options.Password.RequireNonAlphanumeric = false;
-                options.Password.RequireUppercase = true;
-                options.Password.RequireLowercase = false;
-                options.Password.RequiredUniqueChars = 6;
+                //options.Password.RequireDigit = true;
+                options.Password.RequiredLength = 6;
+                //options.Password.RequireNonAlphanumeric = false;
+                //options.Password.RequireUppercase = true;
+                //options.Password.RequireLowercase = false;
+                //options.Password.RequiredUniqueChars = 6;
 
                 // Lockout settings
                 options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(30);

--- a/Machete.Web/StartupConfiguration.cs
+++ b/Machete.Web/StartupConfiguration.cs
@@ -93,12 +93,12 @@ namespace Machete.Web
             services.Configure<IdentityOptions>(options =>
             {
                 // Password settings; we are relying on validation
-                //options.Password.RequireDigit = true;
+                options.Password.RequireDigit = false;
                 options.Password.RequiredLength = 6;
-                //options.Password.RequireNonAlphanumeric = false;
-                //options.Password.RequireUppercase = true;
-                //options.Password.RequireLowercase = false;
-                //options.Password.RequiredUniqueChars = 6;
+                options.Password.RequireNonAlphanumeric = false;
+                options.Password.RequireUppercase = false;
+                options.Password.RequireLowercase = false;
+                options.Password.RequiredUniqueChars = 0;
 
                 // Lockout settings
                 options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(30);

--- a/Machete.Web/ViewModel/AccountViewModels.cs
+++ b/Machete.Web/ViewModel/AccountViewModels.cs
@@ -28,6 +28,8 @@ namespace Machete.Web.ViewModel
         public DateTime CreationDate { get; set; } // Note: not in db - is this used? Db has CreateDate
 
         public DateTime LastLoginDate { get; set; }
+        
+        public bool IsHirer { get; set; }
     }
 
     public class ManageUserViewModel

--- a/Machete.sln.DotSettings
+++ b/Machete.sln.DotSettings
@@ -22,6 +22,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=imagefile/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=immigrantrefugee/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=insuranceexpiration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=jadmin/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=jwks/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=licenseexpirationdate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=livealone/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
helps to resolve https://github.com/SavageLearning/Machete/issues/390 by making it impossible for users to delete jadmin or ndlon usernames; filters out hirers by actual roles